### PR TITLE
If we aren't able to determine the host, use "0.0.0.0" instead of "lo…

### DIFF
--- a/src/main/java/io/vertxbeans/VertxBeansBase.java
+++ b/src/main/java/io/vertxbeans/VertxBeansBase.java
@@ -91,12 +91,13 @@ public class VertxBeansBase {
                     .flatMap(ni -> list(ni.getInetAddresses()).stream())
                     .filter(address -> !address.isAnyLocalAddress())
                     .filter(address -> !address.isMulticastAddress())
+                    .filter(address -> !address.isLoopbackAddress())
                     .filter(address ->!(address instanceof Inet6Address))
                     .map(InetAddress::getHostAddress)
-                    .findFirst().orElse("localhost");
+                    .findFirst().orElse("0.0.0.0");
         } catch (SocketException e) {
             log.warn("Unable to determine network interfaces. Using \"localhost\" as host address.", e);
-            return "localhost";
+            return "0.0.0.0";
        }
     }
 }


### PR DESCRIPTION
If we aren't able to determine the host, use "0.0.0.0" instead of "localhost". It will allow Vertx to listen on all interfaces. Also, skip any loopback address for the host.
