### PR TITLE
Code changes to update changes in vertx 3.4.1

### DIFF
--- a/src/main/java/io/vertxbeans/rxjava/ContextRunner.java
+++ b/src/main/java/io/vertxbeans/rxjava/ContextRunner.java
@@ -1,6 +1,6 @@
 package io.vertxbeans.rxjava;
 
-import rx.Observable;
+import rx.Single;
 
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -25,7 +25,7 @@ public interface ContextRunner {
      * @param <T> the type of object we are creating; e.g., {@code HttpServer}
      * @return an {@code Observable} that either emits a collated {@code List} of items, or an error.
      */
-    <T> Observable<List<T>> execute(int instances, Supplier<Observable<T>> supplier);
+    <T> Single<List<T>> execute(int instances, Supplier<Single<T>> supplier);
     /**
      * Execute user-supplied code on a new event loop and provide the collated results synchronously.
      *
@@ -39,5 +39,5 @@ public interface ContextRunner {
      * @throws ExecutionException if your code raises an error
      * @throws TimeoutException if all of your instances don't provide a result within the timeout
      */
-    <T> List<T> executeBlocking(int instances, Supplier<Observable<T>> supplier, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException;
+    <T> List<T> executeBlocking(int instances, Supplier<Single<T>> supplier, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException;
 }

--- a/src/test/java/io/vertxbeans/rxjava/ContextRunnerTest.java
+++ b/src/test/java/io/vertxbeans/rxjava/ContextRunnerTest.java
@@ -3,7 +3,7 @@ package io.vertxbeans.rxjava;
 import io.vertx.core.Vertx;
 import org.junit.Before;
 import org.junit.Test;
-import rx.Observable;
+import rx.Single;
 
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -30,9 +30,9 @@ public class ContextRunnerTest {
     public void success() throws InterruptedException, ExecutionException, TimeoutException {
         List<String> results = contextRunner.executeBlocking(2, () -> {
             if (Thread.currentThread().getClass().getName().startsWith("io.vertx")){
-                return Observable.just("OK");
+                return Single.just("OK");
             } else{
-                return Observable.error(new RuntimeException("Not on event loop!"));
+                return Single.error(new RuntimeException("Not on event loop!"));
             }
         }, 10, MILLISECONDS);
         assertThat(String.join(".", results), equalTo("OK.OK"));
@@ -40,12 +40,12 @@ public class ContextRunnerTest {
 
     @Test(expected = ExecutionException.class)
     public void failure() throws InterruptedException, ExecutionException, TimeoutException {
-        contextRunner.executeBlocking(2, () -> Observable.error(new RuntimeException()), 10, MILLISECONDS);
+        contextRunner.executeBlocking(2, () -> Single.error(new RuntimeException()), 10, MILLISECONDS);
     }
 
     @Test(expected = TimeoutException.class)
     public void timeout() throws InterruptedException, ExecutionException, TimeoutException {
-        contextRunner.executeBlocking(1, () -> Observable.create(subscriber -> {}), 10, MILLISECONDS);
+        contextRunner.executeBlocking(1, () -> Single.create(subscriber -> {}), 10, MILLISECONDS);
     }
 
 }


### PR DESCRIPTION
Hi Rob,
In order to remove the deprecated methods in our projects for conformity with vertx 3.4.1, some code changes need to be done on vertx-beans. Please review the changes and create a version of vertx beans which can be used with the above changes.

Regards,